### PR TITLE
Fullpath argument for annotation tags

### DIFF
--- a/lib/ress/view_helpers.rb
+++ b/lib/ress/view_helpers.rb
@@ -3,9 +3,7 @@ module Ress
   module ViewHelpers
 
     def ress_annotation_tags(options={})
-      options = { :fullpath => nil }.merge(options)
-      fullpath = options[:fullpath]
-      fullpath ||= request.fullpath
+      fullpath = options[:fullpath] || request.fullpath
 
       path = "#{request.host_with_port}#{fullpath}"
       html = if canonical_request?

--- a/lib/ress/view_helpers.rb
+++ b/lib/ress/view_helpers.rb
@@ -2,8 +2,12 @@ module Ress
 
   module ViewHelpers
 
-    def ress_annotation_tags
-      path = "#{request.host_with_port}#{request.fullpath}"
+    def ress_annotation_tags(options={})
+      options = { :fullpath => nil }.merge(options)
+      fullpath = options[:fullpath]
+      fullpath ||= request.fullpath
+
+      path = "#{request.host_with_port}#{fullpath}"
       html = if canonical_request?
         Ress.alternate_versions.map do |category|
           category.link_tag(request.protocol, path, self)

--- a/spec/ress/view_helpers_spec.rb
+++ b/spec/ress/view_helpers_spec.rb
@@ -53,6 +53,16 @@ describe ActionView::Base do
 
     end
 
+    context 'with fullpath argument' do
+      let(:request) { stub('request', :protocol => 'http://', :host_with_port => 'foo.com', :fullpath => '/bar', :subdomain => '') }
+      before { view.stub(:canonical_request? => true) }
+
+      it 'gerenates the link tags using the fullpath argument instead' do
+        view.ress_annotation_tags(:fullpath => '/notbar').should ==
+          "<link href=\"http://m.foo.com/notbar\" id=\"m\" media=\"stuff\" rel=\"alternate\" />"
+      end
+    end
+
   end
 
 end


### PR DESCRIPTION
Purpose:

In some instances, the mobile or tablet versions of a site do not share the same url structure as their canonical counterpart. In this pull request I expose an optional `:fullpath` argument for the `ress_annotation_tags` method.

Simple example:

Say I visit `www.mysite.com/confirmed` but there is no mobile equivalent url available (say: `m.mysite.com/confirmed` does not exist). The mobile or tablet equivalent might be `m.mysite.com/cant_confirm`. So we'd do that with:

```
ress_annotations_tags(:fullpath => '/cant_confirm')
```

This will create:

```
<link href="http://m.mysite.com/cant_confirm" id="mobile" media="only screen and (max-width: 640px)" rel="alternate">
```

RESS states that html pages should contain all their devise equivalent urls in the head of the html page. In some cases, the url structures are not all the same but you still need to list the other equivalents. This takes care of that.
